### PR TITLE
Increase NP and NBP constants

### DIFF
--- a/include/accel.h
+++ b/include/accel.h
@@ -1,3 +1,5 @@
+#undef __noinline__
+
 #include <glib.h>
 #include "presto.h"
 #include "accelsearch_cmd.h"


### PR DESCRIPTION
Currently in `include/database.h` there is:
```
/* Number of entries in PSR database */
#define NP  3000
#define NBP 200
```

These numbers are too small and this  is causing errors when running `accelsearch_cu`. For instance:
```
$ accelsearch_cu -zmax 200 -wmax 600 -numharm 4 ts_NGC362_01U-trapum_cfbf00000sub_CB.fft

Generating correlation kernels:
  Working candidates in a test format are in 'ts_NGC362_01U-trapum_cfbf00000sub_CB_ACCEL_200_JERK_600.txtcand'.

numcands after while:78
NP value set to small (3000) in $PRESTO/include/database.h
Please increase it and recompile
```
And the resulting files are empty:
```
-rw-r--r-- 1 ubuntu pulsar          0 Apr 11 23:15 ts_NGC362_01U-trapum_cfbf00000sub_CB_ACCEL_200_JERK_600.txtcand
-rw-r--r-- 1 ubuntu pulsar          0 Apr 11 23:16 ts_NGC362_01U-trapum_cfbf00000sub_CB_ACCEL_200_JERK_600
```
Increasing the constants to `#define NP  5000` and `#define NBP  600` fixes the issue.